### PR TITLE
Add background audio and startup frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,11 @@
 <body>
   <video id="camera" autoplay playsinline></video>
   <div id="overlay">
+    <img id="frameOverlay" src="images/frame.png" alt="Frame" />
     <img id="enterGif" src="images/button.gif" alt="Enter" />
     <button id="enterButton">Click to Enter</button>
   </div>
+  <audio id="bgMusic" src="images/Untitled.mp3" loop></audio>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,8 @@ let scrollX = 0;
 let scrollInterval = null;
 let isPaused = false;
 
+const bgMusic = document.getElementById('bgMusic');
+
 // Setup camera
 const video = document.getElementById('camera');
 
@@ -22,6 +24,9 @@ const enterButton = document.getElementById('enterButton');
 
 enterButton.addEventListener('click', () => {
   enterButton.style.display = 'none';
+  if (bgMusic) {
+    bgMusic.play();
+  }
   showRandomGraffiti();
   window.addEventListener('click', showRandomGraffiti);
 });

--- a/style.css
+++ b/style.css
@@ -49,6 +49,16 @@ html, body {
   pointer-events: none;
 }
 
+#frameOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+  pointer-events: none;
+}
+
 .graffiti-image {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
## Summary
- overlay startup screen with a frame image
- play background music when entering the app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e604bcac083239b3122ed9f2db925